### PR TITLE
Fix DevTools height getting clipped at 200px on large viewports

### DIFF
--- a/src/FakeBrowserWindow.module.css
+++ b/src/FakeBrowserWindow.module.css
@@ -89,6 +89,7 @@
 .BrowserContent {
   display: flex;
   flex-direction: column;
+  flex: 1 0 100%;
   overflow: auto;
 }
 
@@ -123,7 +124,7 @@
 
 .Frame {
   width: 100%;
-  flex: 1 0 150px;
+  flex: 0 0 150px;
   border: 0;
 }
 


### PR DESCRIPTION
The DevTools height gets clipped at 200px, independent of how large the viewport is. This fix enables the DevTools to occupy the available space while preserving the other element's sizes, and while preserving the current behavior on mobile.

**Before:**
<img width="2032" alt="Screenshot 2019-08-17 at 19 09 38" src="https://user-images.githubusercontent.com/5282190/63215148-a30b8200-c122-11e9-96b1-8dc8e49dd2a9.png">

**After:**
<img width="2032" alt="Screenshot 2019-08-17 at 19 09 47" src="https://user-images.githubusercontent.com/5282190/63215150-a7379f80-c122-11e9-9e71-2b37f9fc9a46.png">
